### PR TITLE
Image editor modifications

### DIFF
--- a/app/controllers/api/v1/edits_controller.rb
+++ b/app/controllers/api/v1/edits_controller.rb
@@ -1,8 +1,22 @@
 class Api::V1::EditsController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authenticate_user!
+  protect_from_forgery unless: -> { request.format.json? }
 
   def create
+
+    extracted_params = params["editorState"]
+
+    newEdit = Edit.new
+    newEdit.slider_r = extracted_params["sliderRValue"]
+    newEdit.slider_g = extracted_params["sliderGValue"]
+    newEdit.slider_b = extracted_params["sliderBValue"]
+    newEdit.text_body = extracted_params["textBody"]
+    newEdit.upload = Upload.find_by(id: extracted_params["uploadedImage"]["id"])
+    newEdit.user = User.find_by(id: extracted_params["currentUser"]["user_id"])
+
+    newEdit.save
+
   end
 
   def update

--- a/app/controllers/api/v1/exports_controller.rb
+++ b/app/controllers/api/v1/exports_controller.rb
@@ -3,5 +3,12 @@ class Api::V1::ExportsController < ApplicationController
   before_action :authenticate_user!
 
   def create
+    newExport = Export.new
+    newExport.share = params["share"]
+    newExport.user = User.find_by(id: params["user_id"])
+    binding.pry
+    newExport.upload = Upload.find_by(id: params["upload_id"])
+    newExport.save
+    binding.pry
   end
 end

--- a/app/controllers/api/v1/exports_controller.rb
+++ b/app/controllers/api/v1/exports_controller.rb
@@ -6,9 +6,7 @@ class Api::V1::ExportsController < ApplicationController
     newExport = Export.new
     newExport.share = params["share"]
     newExport.user = User.find_by(id: params["user_id"])
-    binding.pry
     newExport.upload = Upload.find_by(id: params["upload_id"])
     newExport.save
-    binding.pry
   end
 end

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,4 +1,7 @@
 class ExportsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate_user!
   def show
+    render json: {current_user: current_user, current_export: Export.find_by(id: params[:id])}
   end
 end

--- a/app/javascript/react/src/App.js
+++ b/app/javascript/react/src/App.js
@@ -4,6 +4,7 @@ import { Router, browserHistory, Route, IndexRoute } from 'react-router';
 import NavBar from './components/NavBar'
 import IndexPage from './containers/IndexPage'
 import ImageEditorContainer from './containers/ImageEditorContainer'
+import ExportShowPage from './containers/ExportShowPage'
 
 const App = props => {
   return(
@@ -11,7 +12,7 @@ const App = props => {
       <Route path='/' component={NavBar}>
         <IndexRoute component={IndexPage}/>
         <Route path='/users/:user_id/uploads/:id' component={ImageEditorContainer}/>
-        {/* <Route path='/users/:user_id/exports/:id' component={ExportShowPage}/> */}
+        <Route path='/users/:user_id/uploads/:upload_id/exports/:id' component={ExportShowPage}/>
       </Route>
     </Router>
   )

--- a/app/javascript/react/src/components/ImageEditor.js
+++ b/app/javascript/react/src/components/ImageEditor.js
@@ -51,161 +51,232 @@ class ImageEditor extends Component {
   }
 
   componentDidMount(){
+    let that = this;
 
-    // if (Object.keys(this.state.current_image).length != 0) {
-      let img = new Image();
-      // img.src = 'https://s3.amazonaws.com/starcation-new-development/uploads/celestial/photo/1/Jupiter_and_its_shrunken_Great_Red_Spot.jpg';
-      img.crossOrigin = "Anonymous";
-      img.src = this.state.current_image.file.url
-      img.onload = function() {
-        let canvasOringinal = document.getElementById('myCanvas');
-        let ctxOriginal = canvasOringinal.getContext('2d');
-        ctxOriginal.drawImage(img, 0, 0);
-        ctxOriginal.textBaseline = 'top';
-        ctxOriginal.font = "100px Arial"
-        ctxOriginal.fillStyle = '#ffffff'
-        ctxOriginal.fillText("Joe", 10, 10);
-        img.style.display = 'none';
-        let originalImageData = ctxOriginal.getImageData(0, 0, canvasOringinal.width, canvasOringinal.height)
-        let originalData = originalImageData.data;
+    let img = new Image();
+    // img.src = 'https://s3.amazonaws.com/starcation-new-development/uploads/celestial/photo/1/Jupiter_and_its_shrunken_Great_Red_Spot.jpg';
+    img.crossOrigin = "Anonymous";
+    img.src = this.state.current_image.file.url
+    img.onload = function() {
+      let canvasOringinal = document.getElementById('myCanvas');
+      let ctxOriginal = canvasOringinal.getContext('2d');
+      ctxOriginal.drawImage(img, 0, 0);
+      ctxOriginal.textBaseline = 'top';
+      ctxOriginal.font = "100px Arial"
+      ctxOriginal.fillStyle = '#ffffff'
+      // ctxOriginal.fillText("Joe", 10, 10);
+      img.style.display = 'none';
+      let originalImageData = ctxOriginal.getImageData(0, 0, canvasOringinal.width, canvasOringinal.height)
+      let originalData = originalImageData.data;
 
-        changeSliderValue(this, originalData)
-      }
-
-      function changeSliderValue(img, originalData) {
-        let canvas = document.getElementById('myCanvas');
-        let ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0);
-        ctx.fillStyle = '#ffffff'
-        ctx.fillText("Joe", 10, 10);
-        img.style.display = 'none';
-        let imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
-        let data = imageData.data;
-
-        let sliderR = document.getElementById('1');
-
-        let changeRChannel = () => {
-          // console.log(sliderR.valueAsNumber)
-          let sliderValue8Bit = sliderR.valueAsNumber/255
-          let i
-          for (i = 0; i < data.length; i += 4) {
-            data[i] = Math.round(originalData[i] * sliderValue8Bit)
-          }
-          ctx.textBaseline = 'top';
-          ctx.font = "100px Arial"
-          ctx.putImageData(imageData, 0, 0)
-          ctx.fillStyle = '#ffffff'
-          ctx.fillText("Joe", 10, 10);
-        }
-
-        let sliderG = document.getElementById('2');
-
-        let changeGChannel = () => {
-          // console.log(sliderG.valueAsNumber)
-          let sliderValue8Bit = sliderG.valueAsNumber/255
-          let i
-          for (i = 0; i < data.length; i += 4) {
-            data[i + 1] = Math.round(originalData[i + 1] * sliderValue8Bit)
-          }
-          ctx.textBaseline = 'top';
-          ctx.font = "100px Arial"
-          ctx.putImageData(imageData, 0, 0)
-          ctx.fillStyle = '#ffffff'
-          ctx.fillText("Joe", 10, 10);
-        }
-
-        let sliderB = document.getElementById('3');
-
-        let changeBChannel = () => {
-          // console.log(sliderB.valueAsNumber)
-          let sliderValue8Bit = sliderB.valueAsNumber/255
-          let i
-          for (i = 0; i < data.length; i += 4) {
-            data[i + 2] = Math.round(originalData[i + 2] * sliderValue8Bit)
-          }
-          ctx.textBaseline = 'top';
-          ctx.font = "100px Arial"
-          ctx.putImageData(imageData, 0, 0)
-          ctx.fillStyle = '#ffffff'
-          ctx.fillText("Joe", 10, 10);
-        }
-
-        sliderR.addEventListener('input',changeRChannel);
-        sliderG.addEventListener('input',changeGChannel);
-        sliderB.addEventListener('input',changeBChannel);
-
-
-
-
-
-
-
-
-        let uploadImage = (e) => {
-          // debugger
-          let currentCanvas = document.getElementById('myCanvas');
-          let dataURL = currentCanvas.toDataURL()
-
-          let newBlob = dataURLtoBlob(dataURL)
-          let file = new File([newBlob], "editedImage_1.png");
-
-          let formPayLoad = new FormData();
-          formPayLoad.append('file', file);
-
-          fetch(`/api/v1/users/${1}/images`, {
-            credentials: 'same-origin',
-            headers: {},
-            method: 'POST',
-            body: formPayLoad
-          })
-          .then(response => {
-            if (response.ok) {
-              return response;
-            } else {
-              let errorMessage = `${response.status} (${response.statusText})`,
-              error = new Error(errorMessage);
-              throw(error);
-            }
-          })
-          .catch(error => console.error(`Error in fetch: ${error.message}`));
-
-
-          // function from: https://stackoverflow.com/questions/21707595/how-to-save-base64-image-in-blob-with-carrierwave-in-rails4
-          function dataURLtoBlob(dataURL) {
-
-            // Decode the dataURL
-            var binary = atob(dataURL.split(',')[1]);
-
-            // Create 8-bit unsigned array
-            var array = [];
-            for(var i = 0; i < binary.length; i++) {
-              array.push(binary.charCodeAt(i));
-            }
-
-            // Return our Blob object
-            return new Blob([new Uint8Array(array)], {type: 'image/png'});
-          }
-
-        }
-        let uploadButton = document.getElementById('upload-button')
-        uploadButton.addEventListener('click', uploadImage)
-      }
+      changeSliderValue(this, originalData, that)
     }
-  // }
+
+    function changeSliderValue(img, originalData, that) {
+      let canvas = document.getElementById('myCanvas');
+      let ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      ctx.fillStyle = '#ffffff'
+      // ctx.fillText("Joe", 10, 10);
+      img.style.display = 'none';
+      let imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      let data = imageData.data;
+      let textToPaint = "Joe"
 
 
-  // shouldComponentUpdate(nextProps, nextState){
-  //   return false;
-  // }
+
+      let sliderR = document.getElementById('1');
+
+      let changeRChannel = () => {
+        // console.log(sliderR.valueAsNumber)
+        let sliderValue8Bit = sliderR.valueAsNumber/255
+        let i
+        for (i = 0; i < data.length; i += 4) {
+          data[i] = Math.round(originalData[i] * sliderValue8Bit)
+        }
+        ctx.textBaseline = 'top';
+        ctx.font = "100px Arial"
+        ctx.putImageData(imageData, 0, 0)
+        ctx.fillStyle = '#ffffff'
+        ctx.fillText(textToPaint, 10, 10);
+      }
+
+      let sliderG = document.getElementById('2');
+
+      let changeGChannel = () => {
+        // console.log(sliderG.valueAsNumber)
+        let sliderValue8Bit = sliderG.valueAsNumber/255
+        let i
+        for (i = 0; i < data.length; i += 4) {
+          data[i + 1] = Math.round(originalData[i + 1] * sliderValue8Bit)
+        }
+        ctx.textBaseline = 'top';
+        ctx.font = "100px Arial"
+        ctx.putImageData(imageData, 0, 0)
+        ctx.fillStyle = '#ffffff'
+        ctx.fillText(textToPaint, 10, 10);
+      }
+
+      let sliderB = document.getElementById('3');
+
+      let changeBChannel = () => {
+        // console.log(sliderB.valueAsNumber)
+        let sliderValue8Bit = sliderB.valueAsNumber/255
+        let i
+        for (i = 0; i < data.length; i += 4) {
+          data[i + 2] = Math.round(originalData[i + 2] * sliderValue8Bit)
+        }
+        ctx.textBaseline = 'top';
+        ctx.font = "100px Arial"
+        ctx.putImageData(imageData, 0, 0)
+        ctx.fillStyle = '#ffffff'
+        ctx.fillText(textToPaint, 10, 10);
+      }
+
+      sliderR.addEventListener('input',changeRChannel);
+      sliderG.addEventListener('input',changeGChannel);
+      sliderB.addEventListener('input',changeBChannel);
+
+
+
+
+
+      // let sliderR = document.getElementById('1');
+      // let sliderG = document.getElementById('2');
+      // let sliderB = document.getElementById('3');
+      //
+      // let changeSliderValue = (id_number) => {
+      //   // console.log(sliderB.valueAsNumber)
+      //   let sliderValue8Bit = sliderB.valueAsNumber/255
+      //   let i
+      //   for (i = 0; i < data.length; i += 4) {
+      //     data[id_number] = Math.round(originalData[id_number] * sliderValue8Bit)
+      //   }
+      //   ctx.textBaseline = 'top';
+      //   ctx.font = "100px Arial"
+      //   ctx.putImageData(imageData, 0, 0)
+      //   ctx.fillStyle = '#ffffff'
+      //   ctx.fillText("Joe", 10, 10);
+      // }
+      //
+      // let redWrapper = () => {
+      //   changeSliderValue(1)
+      // }
+      //
+      //
+      //
+      // sliderR.addEventListener('input', redWrapper);
+      // sliderG.addEventListener('input',changeSliderValue(2));
+      // sliderB.addEventListener('input',changeSliderValue(3));
+
+
+
+
+
+
+
+
+      let uploadImage = (e) => {
+        let currentCanvas = document.getElementById('myCanvas');
+        let dataURL = currentCanvas.toDataURL()
+
+        let upload_id = that.state.current_image.id
+        let user_id = that.state.current_user.user_id
+
+        let newBlob = dataURLtoBlob(dataURL)
+        let lastSlashIndex = that.state.current_image.file.url.lastIndexOf("/")
+        let originalFileName = that.state.current_image.file.url.substr(lastSlashIndex + 1, that.state.current_image.file.url.length)
+        let file = new File([newBlob], `upload_id_${upload_id}_user_id_${user_id}_${originalFileName}`);
+
+        let formPayLoad = new FormData();
+        formPayLoad.append('share', file);
+
+
+        fetch(`/api/v1/users/${user_id}/uploads/${upload_id}/exports`, {
+          credentials: 'same-origin',
+          headers: {},
+          method: 'POST',
+          body: formPayLoad
+        })
+        .then(response => {
+          if (response.ok) {
+            return response;
+          } else {
+            let errorMessage = `${response.status} (${response.statusText})`,
+            error = new Error(errorMessage);
+            throw(error);
+          }
+        })
+        .catch(error => console.error(`Error in fetch: ${error.message}`));
+
+
+        // function from: https://stackoverflow.com/questions/21707595/how-to-save-base64-image-in-blob-with-carrierwave-in-rails4
+        function dataURLtoBlob(dataURL) {
+
+          // Decode the dataURL
+          var binary = atob(dataURL.split(',')[1]);
+
+          // Create 8-bit unsigned array
+          var array = [];
+          for(var i = 0; i < binary.length; i++) {
+            array.push(binary.charCodeAt(i));
+          }
+
+          // Return our Blob object
+          return new Blob([new Uint8Array(array)], {type: 'image/png'});
+        }
+
+      }
+      let uploadButton = document.getElementById('upload-button')
+      uploadButton.addEventListener('click', uploadImage)
+
+
+
+
+
+
+
+
+      let saveEditorState = () => {
+        let statePayLoad = {
+          sliderRValue: sliderR.valueAsNumber,
+          sliderGValue: sliderG.valueAsNumber,
+          sliderBValue: sliderB.valueAsNumber,
+          currentUser: that.state.current_user,
+          uploadedImage: that.state.current_image,
+          textBody: textToPaint
+        }
+
+        let user_id = that.state.current_user.user_id
+        let upload_id = that.state.current_image.id
+        fetch(`/api/v1/users/${user_id}/uploads/${upload_id}/edits`,{
+          credentials: 'same-origin',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+          },
+          method: 'POST',
+          body: JSON.stringify({ editorState: statePayLoad })
+        })
+        // .then(response => response.json())
+        // .then(body => {
+        //
+        // })
+
+        // that.setState({current_edit: sliderRValue})
+      }
+
+      let saveStateButton = document.getElementById('save-state-button')
+      saveStateButton.addEventListener('click', saveEditorState)
+
+    }
+  }
 
   render(){
     return(
       <div>
         {/* <canvas id="myCanvas" width="300" height="227"/> */}
         <canvas id="myCanvas" width="500" height="500"/>
-        <div>
-          <button id="upload-button">Upload image</button>
-        </div>
           <div>
             <SliderTile
               key = {1}
@@ -226,6 +297,12 @@ class ImageEditor extends Component {
               id = {"3"}
               value = {"255"}
             />
+            <div>
+              <button id="upload-button">Upload image</button>
+            </div>
+            <div>
+              <button id="save-state-button">Save edit</button>
+            </div>
           </div>
           <h3>This is rendered in react</h3>
       </div>

--- a/app/javascript/react/src/components/ImageEditor.js
+++ b/app/javascript/react/src/components/ImageEditor.js
@@ -13,38 +13,6 @@ class ImageEditor extends Component {
     }
   }
 
-  // // get initial state before the page renders via GET/fetch
-  // componentWillMount(){
-  //   let that = this;
-  //   let user_id = this.props.params.user_id;
-  //   let id = this.props.params.id;
-  //   fetch(`/users/${user_id}/uploads/${id}.json`, {
-  //     credentials: 'same-origin',
-  //     method: 'GET',
-  //     headers: { 'Content-Type':'application/json'}
-  //   })
-  //   .then(response => {
-  //     if (response.ok) {
-  //       return response;
-  //     } else {
-  //       let errorMessage = `${response.status} (${response.statusText})`,
-  //       error = new Error(errorMessage);
-  //       throw(error);
-  //     }
-  //   })
-  //   .then(response => response.json())
-  //   .then(body => {
-  //     // debugger
-  //     that.setState({
-  //       current_user: body.current_user,
-  //       current_image: body.clicked_image,
-  //       current_edit: body.specific_edit
-  //
-  //     })
-  //   })
-  //   .catch(error => console.error(`Error in fetch: ${error.message}`));
-  // }
-
   // page will only render on page load
   shouldComponentUpdate(){
     return false

--- a/app/javascript/react/src/components/ImageEditor.js
+++ b/app/javascript/react/src/components/ImageEditor.js
@@ -24,6 +24,7 @@ class ImageEditor extends Component {
     let img = new Image();
     // img.src = 'https://s3.amazonaws.com/starcation-new-development/uploads/celestial/photo/1/Jupiter_and_its_shrunken_Great_Red_Spot.jpg';
     img.crossOrigin = "Anonymous";
+    // img.src = this.state.current_image.file.url + "?edit=1"
     img.src = this.state.current_image.file.url
     img.onload = function() {
       let canvasOringinal = document.getElementById('myCanvas');

--- a/app/javascript/react/src/components/ImageTile.js
+++ b/app/javascript/react/src/components/ImageTile.js
@@ -2,9 +2,17 @@ import React from 'react';
 import { Link } from 'react-router'
 
 const ImageTile = (props) => {
+  let linkComponent;
+  if (props.image_type_flag === 1) {
+    linkComponent = <Link to={`/users/${props.user_id}/uploads/${props.id}`}><img className="image-tile" src={props.image.url} alt="user image upload"/></Link>
+  } else if (props.image_type_flag === 2) {
+    linkComponent = <div></div>
+  } else {
+    linkComponent = <Link to={`/users/${props.user_id}/uploads/${props.upload_id}/exports/${props.id}`}><img className="image-tile" src={props.image.url} alt="user image upload"/></Link>
+  }
   return(
     <div>
-      <Link to={`/users/${props.user_id}/uploads/${props.id}`}><img className="image-tile" src={props.image.url} alt="user image upload"/></Link>
+      {linkComponent}
     </div>
   )
 }

--- a/app/javascript/react/src/components/ImageTile.js
+++ b/app/javascript/react/src/components/ImageTile.js
@@ -4,11 +4,11 @@ import { Link } from 'react-router'
 const ImageTile = (props) => {
   let linkComponent;
   if (props.image_type_flag === 1) {
-    linkComponent = <Link to={`/users/${props.user_id}/uploads/${props.id}`}><img className="image-tile" src={props.image.url} alt="user image upload"/></Link>
+    linkComponent = <Link to={`/users/${props.user_id}/uploads/${props.id}`}><img className="image-tile" crossOrigin="anonymous" src={props.image.url} alt="user image upload"/></Link>
   } else if (props.image_type_flag === 2) {
     linkComponent = <div></div>
   } else {
-    linkComponent = <Link to={`/users/${props.user_id}/uploads/${props.upload_id}/exports/${props.id}`}><img className="image-tile" src={props.image.url} alt="user image upload"/></Link>
+    linkComponent = <Link to={`/users/${props.user_id}/uploads/${props.upload_id}/exports/${props.id}`}><img crossOrigin="anonymous" className="image-tile" src={props.image.url} alt="user image upload"/></Link>
   }
   return(
     <div>

--- a/app/javascript/react/src/containers/ExportShowPage.js
+++ b/app/javascript/react/src/containers/ExportShowPage.js
@@ -1,0 +1,43 @@
+import React, {Component} from 'react';
+
+class ExportShowPage extends Component {
+  constructor(props){
+    super(props)
+    this.state = {
+      current_user: {},
+      current_export: {}
+    }
+  }
+
+  componentDidMount() {
+    let that = this
+    let user_id = this.props.params.user_id
+    let upload_id = this.props.params.upload_id
+    let id = this.props.params.id
+    fetch(`/users/${user_id}/uploads/${upload_id}/exports/${id}`, {
+      credentials: 'same-origin',
+      method: 'GET',
+      headers: { 'Content-Type':'application/json'}
+    })
+    .then(response => response.json())
+    .then(body => {
+      that.setState({current_user: body.current_user, current_export: body.current_export})
+    })
+  }
+
+  render() {
+    let imageToLoad;
+    if (Object.keys(this.state.current_export).length > 0) {
+      imageToLoad = <img src={this.state.current_export.share.url} />
+    } else {
+      imageToLoad = <div></div>
+    }
+    return(
+      <div>
+        {imageToLoad}
+      </div>
+    )
+  }
+}
+
+export default ExportShowPage

--- a/app/javascript/react/src/containers/ImageEditorContainer.js
+++ b/app/javascript/react/src/containers/ImageEditorContainer.js
@@ -17,7 +17,7 @@ class ImageEditorContainer extends Component {
     let that = this;
     let user_id = this.props.params.user_id;
     let id = this.props.params.id;
-    fetch(`/users/${user_id}/uploads/${id}.json`, {
+    fetch(`/users/${user_id}/uploads/${id}`, {
       credentials: 'same-origin',
       method: 'GET',
       headers: { 'Content-Type':'application/json'}

--- a/app/javascript/react/src/containers/IndexPage.js
+++ b/app/javascript/react/src/containers/IndexPage.js
@@ -106,7 +106,17 @@ class IndexPage extends Component {
     }
 
     let exportedImageTiles;
-    if (this.state.exports > 0) {
+    if (this.state.exports.length > 0) {
+      exportedImageTiles = this.state.exports.map(exportedImage => {
+        return(
+          <ImageTile
+            key = {new Date().getTime() + exportedImage.id}
+            id = {exportedImage.id}
+            image = {exportedImage.share}
+            user_id = {exportedImage.user_id}
+          />
+        )
+      })
 
     } else {
       exportedImageTiles = <p>You haven't saved any photos yet for comments!</p>

--- a/app/javascript/react/src/containers/IndexPage.js
+++ b/app/javascript/react/src/containers/IndexPage.js
@@ -91,6 +91,8 @@ class IndexPage extends Component {
             id = {upload.id}
             image = {upload.file}
             user_id = {upload.user_id}
+            image_type_flag = {1}
+            upload_id = {upload.id}
           />
         )
       })
@@ -114,6 +116,8 @@ class IndexPage extends Component {
             id = {exportedImage.id}
             image = {exportedImage.share}
             user_id = {exportedImage.user_id}
+            image_type_flag = {3}
+            upload_id = {exportedImage.upload_id}
           />
         )
       })

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,6 @@ class Comment < ApplicationRecord
   belongs_to :upload
 
   validates :user_id, presence: true
-  validates :image_id, presence: true
+  validates :upload_id, presence: true
   validates :body, presence: true
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,9 +1,7 @@
 class Export < ApplicationRecord
   belongs_to :user
   belongs_to :upload
-
-  validates :user_id, presence: true
-  validates :image_id, presence: true
+  
   validates :share, presence: true
 
   mount_uploader :share, ShareUploader

--- a/db/migrate/20171106210312_drop_table_exports.rb
+++ b/db/migrate/20171106210312_drop_table_exports.rb
@@ -1,0 +1,23 @@
+class DropTableExports < ActiveRecord::Migration[5.1]
+  def up
+    drop_table :exports
+    create_table :exports do |t|
+      t.belongs_to :user, null: false
+      t.belongs_to :upload, null: false
+      t.string :share, null: false
+
+      t.timestamps null: false
+    end
+  end
+
+  def down
+    drop_table :exports
+    create_table :exports do |t|
+      t.belongs_to :user, null: false
+      t.belongs_to :image, null: false
+      t.string :share, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171105172722) do
+ActiveRecord::Schema.define(version: 20171106210312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,11 +40,11 @@ ActiveRecord::Schema.define(version: 20171105172722) do
 
   create_table "exports", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "image_id", null: false
+    t.bigint "upload_id", null: false
     t.string "share", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["image_id"], name: "index_exports_on_image_id"
+    t.index ["upload_id"], name: "index_exports_on_upload_id"
     t.index ["user_id"], name: "index_exports_on_user_id"
   end
 


### PR DESCRIPTION
I added a major bug fix to the editor. I kept receiving a CORS error when loading the image into `<canvas>` despite having added the `crossOrigin = "Anonymous"` attribute to the img in the editor. I had disabled cache in the dev tools, so the error did not persist. I realized that since the image was getting loaded twice, once in the index page, and another time in the editor, the app was loading the image in the index without CORS support, and on the editor page, loading that image from the cache.  The simplest way to fix this was to add  `crossOrigin = "Anonymous"` to the `<img>`'s in the index page. I could have also added a cache buster string to the URL in the editor page (e.g. `let newURL = oldURL + "?edit=1"`), but this was a cleaner solution.