### PR TITLE
fixed bug with version of foundation - when I ran bundle update it up…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jbuilder', '~> 2.5'
 
 
 ### joemusacchia added these gems
-gem 'foundation-rails'
+gem 'foundation-rails', '~> 5.4.5.0'
 gem 'webpacker'
 gem 'devise'
 gem 'carrierwave', '~>1.0'
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'valid_attribute'
   gem 'shoulda'#, require: false
+  gem 'shoulda-matchers', require: false
   gem 'dotenv-rails'
   gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,6 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
-    babel-source (5.8.35)
-    babel-transpiler (0.7.0)
-      babel-source (>= 4.0, < 6)
-      execjs (~> 2.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
@@ -240,10 +236,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
-    foundation-rails (6.4.1.3)
+    foundation-rails (5.4.5.0)
       railties (>= 3.1.0)
-      sass (>= 3.3.0, < 3.5)
-      sprockets-es6 (>= 0.9.0)
+      sass (>= 3.2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     http-cookie (1.0.3)
@@ -379,10 +374,6 @@ GEM
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-es6 (0.9.2)
-      babel-source (>= 5.8.11)
-      babel-transpiler
-      sprockets (>= 3.0.0)
     sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -428,7 +419,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   fog
-  foundation-rails
+  foundation-rails (~> 5.4.5.0)
   jbuilder (~> 2.5)
   jquery-rails
   launchy
@@ -442,6 +433,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data


### PR DESCRIPTION
fixed bug with version of foundation - when I ran bundle update it updated foundation-rails and the new version broke the `application.erb.html` file. I discovered that I needed version 5.4.5.0 which worked in a previous commit. To fix the issue, I uninstalled the `foundation-rails` gem from the system via `bundle uninstall foundation-rails` and removed all versions. Then, I hard-coded the working version into my Gemfile: `gem 'foundation-rails', '~> 5.4.5.0'`; after this, I ran `bundle install` again which installed the correct version. The app successfully booted up. I found which version I needed by checking the commit history for this repo. Thank heavens for GitHub!