### PR TITLE
Added stroke and impact text support for GET, POST, and PATCH in the editor

### DIFF
--- a/app/javascript/react/src/components/ImageEditor.js
+++ b/app/javascript/react/src/components/ImageEditor.js
@@ -73,11 +73,20 @@ class ImageEditor extends Component {
           data[i + 1] = Math.round(originalData[i + 1] * getGSliderFloat)
           data[i + 2] = Math.round(originalData[i + 2] * getBSliderFloat)
         }
-        ctx.textBaseline = 'top';
-        ctx.font = "100px Arial"
+
         ctx.putImageData(imageData, 0, 0)
+
+        let splitText = textToPaint.split('\n');
+        ctx.font = "100px Impact";
         ctx.fillStyle = '#ffffff';
-        ctx.fillText(textToPaint, 10, 10);
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'center';
+        ctx.strokeStyle = 'black';
+        ctx.lineWidth = 10;
+        for (let i = 0; i < splitText.length; i++) {
+          ctx.strokeText(splitText[i], canvas.width/2, (100 * i));
+          ctx.fillText(splitText[i], canvas.width/2, (100 * i));
+        }
       }
 
 
@@ -86,17 +95,28 @@ class ImageEditor extends Component {
 
 
 
+      // Future version of this code will be DRY'ed up and all of the text rendering
+      // will be defined in a JS class; maybe even instantiate all of the canvas
+      // code in that class
       let changeRChannel = () => {
         let sliderValue8Bit = sliderR.valueAsNumber/255
         let i
         for (i = 0; i < data.length; i += 4) {
           data[i] = Math.round(originalData[i] * sliderValue8Bit)
         }
-        ctx.textBaseline = 'top';
-        ctx.font = "100px Arial"
         ctx.putImageData(imageData, 0, 0)
+
+        let splitText = textToPaint.split('\n');
+        ctx.font = "100px Impact";
         ctx.fillStyle = '#ffffff';
-        ctx.fillText(textToPaint, 10, 10);
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'center';
+        ctx.strokeStyle = 'black';
+        ctx.lineWidth = 10;
+        for (let i = 0; i < splitText.length; i++) {
+          ctx.strokeText(splitText[i], canvas.width/2, (100 * i));
+          ctx.fillText(splitText[i], canvas.width/2, (100 * i));
+        }
       }
 
 
@@ -106,11 +126,19 @@ class ImageEditor extends Component {
         for (i = 0; i < data.length; i += 4) {
           data[i + 1] = Math.round(originalData[i + 1] * sliderValue8Bit)
         }
-        ctx.textBaseline = 'top';
-        ctx.font = "100px Arial"
         ctx.putImageData(imageData, 0, 0)
+
+        let splitText = textToPaint.split('\n');
+        ctx.font = "100px Impact";
         ctx.fillStyle = '#ffffff';
-        ctx.fillText(textToPaint, 10, 10);
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'center';
+        ctx.strokeStyle = 'black';
+        ctx.lineWidth = 10;
+        for (let i = 0; i < splitText.length; i++) {
+          ctx.strokeText(splitText[i], canvas.width/2, (100 * i));
+          ctx.fillText(splitText[i], canvas.width/2, (100 * i));
+        }
       }
 
 
@@ -120,11 +148,19 @@ class ImageEditor extends Component {
         for (i = 0; i < data.length; i += 4) {
           data[i + 2] = Math.round(originalData[i + 2] * sliderValue8Bit)
         }
-        ctx.textBaseline = 'top';
-        ctx.font = "100px Arial"
         ctx.putImageData(imageData, 0, 0)
+
+        let splitText = textToPaint.split('\n');
+        ctx.font = "100px Impact";
         ctx.fillStyle = '#ffffff';
-        ctx.fillText(textToPaint, 10, 10);
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'center';
+        ctx.strokeStyle = 'black';
+        ctx.lineWidth = 10;
+        for (let i = 0; i < splitText.length; i++) {
+          ctx.strokeText(splitText[i], canvas.width/2, (100 * i));
+          ctx.fillText(splitText[i], canvas.width/2, (100 * i));
+        }
       }
 
       sliderR.addEventListener('input',changeRChannel);
@@ -273,15 +309,15 @@ class ImageEditor extends Component {
         }
         ctx.putImageData(imageData, 0, 0)
 
-        let rawText = event.target.value
-        let splitText = rawText.split('\n');
+        textToPaint = event.target.value
+        let splitText = textToPaint.split('\n');
+        ctx.font = "100px Impact";
+        ctx.fillStyle = '#ffffff';
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'center';
+        ctx.strokeStyle = 'black';
+        ctx.lineWidth = 10;
         for (let i = 0; i < splitText.length; i++) {
-          ctx.font = "100px Impact";
-          ctx.fillStyle = '#ffffff';
-          ctx.textBaseline = 'top';
-          ctx.textAlign = 'center';
-          ctx.strokeStyle = 'black';
-          ctx.lineWidth = 10;
           ctx.strokeText(splitText[i], canvas.width/2, (100 * i));
           ctx.fillText(splitText[i], canvas.width/2, (100 * i));
         }

--- a/app/javascript/react/src/components/ImageEditor.js
+++ b/app/javascript/react/src/components/ImageEditor.js
@@ -261,7 +261,6 @@ class ImageEditor extends Component {
 
 
       let handleTextChange = (event) => {
-        textToPaint = event.target.value
         let getRSliderFloat = sliderR.valueAsNumber/255
         let getGSliderFloat = sliderG.valueAsNumber/255
         let getBSliderFloat = sliderB.valueAsNumber/255
@@ -272,11 +271,20 @@ class ImageEditor extends Component {
           data[i + 1] = Math.round(originalData[i + 1] * getGSliderFloat)
           data[i + 2] = Math.round(originalData[i + 2] * getBSliderFloat)
         }
-        ctx.textBaseline = 'top';
-        ctx.font = "100px Arial"
         ctx.putImageData(imageData, 0, 0)
-        ctx.fillStyle = '#ffffff'
-        ctx.fillText(textToPaint, 10, 10);
+
+        let rawText = event.target.value
+        let splitText = rawText.split('\n');
+        for (let i = 0; i < splitText.length; i++) {
+          ctx.font = "100px Impact";
+          ctx.fillStyle = '#ffffff';
+          ctx.textBaseline = 'top';
+          ctx.textAlign = 'center';
+          ctx.strokeStyle = 'black';
+          ctx.lineWidth = 10;
+          ctx.strokeText(splitText[i], canvas.width/2, (100 * i));
+          ctx.fillText(splitText[i], canvas.width/2, (100 * i));
+        }
 
       }
 


### PR DESCRIPTION
I wanted to make my app look/feel/function more like a meme generator, so I added impact/stroke text to the image editor with multi-line text.  I prototyped it by first changing the font during typing (i.e. in the function watched by the `change` and `keyup` event handlers). Then, to make sure that the text is properly rendered when text is loaded from props/the database, I added the same functionality to the portion of the code when the text is first rendered. Lastly, to make sure the text style persists when slider values are changed, I added the same code to each of the functions watching the slider event handlers.

The future version of this code will seek to refactor the `<canvas>` portions so that the code is DRYer and more efficient.