### PR TITLE
added file whitelisting on both the frontend and backend

### DIFF
--- a/app/javascript/react/src/containers/IndexPage.js
+++ b/app/javascript/react/src/containers/IndexPage.js
@@ -180,7 +180,10 @@ class IndexPage extends Component {
             </div>
             <div className="small-3 medium-3 large-3 large-offset-6 medium-offset-6 small-offset-6 cell image-upload">
                 <div className="upload-button-wrapper">
-                  <Dropzone onDrop={this.readFile} className="button-dropzone">
+                  <Dropzone
+                    accept="image/jpeg, image/png"
+                    onDrop={this.readFile} className="button-dropzone"
+                  >
                     <button className="upload-button">Upload a new image</button>
                   </Dropzone>
                 </div>

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -51,9 +51,9 @@ class FileUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg png) # these are extensions and not MIMEs so jpeg and jpg need to be here
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/uploaders/share_uploader.rb
+++ b/app/uploaders/share_uploader.rb
@@ -51,9 +51,9 @@ class ShareUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg png) # these are extensions and not MIMEs so jpeg and jpg need to be here
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.


### PR DESCRIPTION
To avoid users from uploading large files (like videos) and incorrect file types that will break the app, I added whitelisting for extensions `jpeg`, `jpg`, and `png`.  As it stands now, the app converts both file types to png when 'exporting'.

The frontend was quite easy. All I had to do was add an `accept` prop to the `<Dropzone>` component, like so:
```
accept="image/jpeg, image/png"
```

For the backend, I merely had to uncomment the whitelisting methods in my `file_uploader.rb` and `share_uploader.rb` `carrierwave` image uploaders (and remove `gif` since the editor doesn't currently support that file type), like so:
```
def extension_whitelist
  %w(jpg jpeg png)
end
```
The whitelisting is so effective in `<Dropzone>` that the backend whitelisting might not even be necessary, but redundancy can't hurt!